### PR TITLE
Fix the loading message #79

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@
 
   <body class="page">
     <div class="loading">
-      Loading...
+      <p class="loading__text">Loading...</p>
     </div>
-    <main role="main">
+    <main class="main">
       <article class="">
         <header class="top">
           <div class="title__container">

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -28,10 +28,19 @@
 }
 
 .loading {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
   position: fixed;
-  top: 50%;
-  left: 50%;
+  top: 0;
+  left: 0;
+  width: 100%;
   z-index: 10;
+}
+
+.main {
+  display: none;
 }
 
 /* Horizontal margins */

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -12,4 +12,5 @@ $(document).ready(function() {
 
 $(window).on('load', function() {
   $('.loading').fadeOut();
+  $('.main').fadeIn();
 });


### PR DESCRIPTION
Show it at the center of the screen; hide the content until loaded and fade it in once loaded.